### PR TITLE
Export `null` when not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,12 @@ var other = !osx && !win
 var fs    = require('fs')
 
 if (other) {
-  module.exports = require('which').sync('firefox')
+  try {
+    module.exports = require('which').sync('firefox')
+  } catch (_) {
+    module.exports = null
+  }
+
 } else
 if (osx) {
   var regPath = '/Applications/Firefox.app/Contents/MacOS/firefox'
@@ -28,4 +33,6 @@ if (osx) {
       break
     }
   }
+
+  module.exports = module.exports || null
 }


### PR DESCRIPTION
I'm on Linux and I don't have Firefox installed (shocking I'm sure).

Trying to run smokestack causes an _Error_ to be thrown by `which`:

``` bash
$ browserify test/index.js | smokestack -b chrome | faucet

/home/kenan/.npm-packages/lib/node_modules/smokestack/node_modules/firefox-location/node_modules/which/which.js:78
  throw new Error("not found: "+cmd)
        ^
Error: not found: firefox
    at Function.whichSync [as sync] (/home/kenan/.npm-packages/lib/node_modules/smokestack/node_modules/firefox-location/node_modules/which/which.js:78:9)
    at Object.<anonymous> (/home/kenan/.npm-packages/lib/node_modules/smokestack/node_modules/firefox-location/index.js:7:37)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/home/kenan/.npm-packages/lib/node_modules/smokestack/index.js:4:16)
    at Module._compile (module.js:456:26)
not ok 1 no plan found
not ok 2 no assertions found
⨯ fail  2
```

So this error needs to be caught by either this module or smokestack itself when it does `require('firefox-location')`, otherwise it's impossible to use smokestack without having _both_ Chrome and Firefox installed.
