### PR TITLE
Return null when Firefox is not found on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,20 +19,13 @@ if (osx) {
     ? regPath
     : altPath
 } else {
-  var suffix = '\\Mozilla Firefox\\firefox.exe';
-  var prefixes = [
+  var suffix = '\\Mozilla Firefox\\firefox.exe'
+  module.exports = [
       process.env.LOCALAPPDATA
     , process.env.PROGRAMFILES
     , process.env['PROGRAMFILES(X86)']
-  ]
-
-  for (var i = 0; i < prefixes.length; i++) {
-    var exe = prefixes[i] + suffix
-    if (fs.existsSync(exe)) {
-      module.exports = exe
-      break
-    }
-  }
-
-  module.exports = module.exports || null
+  ].reduce(function (existing, prefix) {
+    var exe = prefix + suffix
+    return existing || fs.existsSync(exe) ? exe : null
+  }, null)
 }


### PR DESCRIPTION
Fixes #2.

This line had a bug:

``` js
module.exports = module.exports || null // => {}
```

Since `module.exports` defaults to `{}` (truthy), it wouldn't return null.
