### PR TITLE
Don't check every file if exe is found

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,6 @@ if (osx) {
     , process.env['PROGRAMFILES(X86)']
   ].reduce(function (existing, prefix) {
     var exe = prefix + suffix
-    return existing || fs.existsSync(exe) ? exe : null
+    return existing || (fs.existsSync(exe) ? exe : null)
   }, null)
 }


### PR DESCRIPTION
I had a small bug in that last PR.

``` js
node
> 'a' || true ? 'b' : null
'b'
> 'a' || (true ? 'b' : null)
'a'
>
```

If multiple paths are valid, it used to return the first one right away. I accidently wrote it so it checks every path, even after it has found a valid one, and returns the last ~~valid~~ path.

I don't know how significant it is...

**_Edit**_

It turns out that it is quite significant.

``` js
C:\Windows\system32>node
> 'a' || false ? 'b' : null
'b'
> 'a' || (false ? 'b' : null)
'a'
>
```

If any path is valid, it will end up exporting the last path, even if that path is invalid.
